### PR TITLE
Enforce uniform error reporting

### DIFF
--- a/docs/authentication-and-authorization.md
+++ b/docs/authentication-and-authorization.md
@@ -111,17 +111,6 @@ as well as WeChat-specific functionalities.
         | --- | ---- | ----------- |
         | `uclcssaSessionKey` | `string` | Key representing a user session. |
 
-    !!! failure "Missing POST body"
-        **Status Code**: `400 Bad Request`
-
-        **Response Body**:
-
-        ```json
-        {
-            "error": "@bad-request/missing-body"
-        }
-        ```
-    
     !!! failure "Missing required key(s)"
         **Status Code**: `400 Bad Request`
 
@@ -129,7 +118,7 @@ as well as WeChat-specific functionalities.
 
         ```json
         {
-            "error": "Bad request: missing one or more of { appId, appSecret, code }."
+            "error": "@bad-request/missing-required-keys"
         }
         ```
 
@@ -173,7 +162,7 @@ that a valid `uclcssaSessionKey` is required.
 
         ```json
         {
-            "error": "@bad-request/missing-email"
+            "error": "@bad-request/missing-required-keys"
         }
         ```
 

--- a/docs/authentication-and-authorization.md
+++ b/docs/authentication-and-authorization.md
@@ -86,11 +86,11 @@ as well as WeChat-specific functionalities.
     }
     ```
 
-    | Key | Type | Description | Constraints | Default | Required |
-    | --------- | ---- | ----------- | ----------- | ------- | -------- |
-    | `appId` | `string` | Obtained from WeChat client. | N/A | N/A | Yes |
-    | `appSecret` | `string` | Obtained from WeChat client. | N/A | N/A | Yes |
-    | `code` | `string` | Obtained from WeChat client. | N/A | N/A | Yes |
+    | Key         | Type     | Description                  | Constraints | Default | Required |
+    | ----------- | -------- | ---------------------------- | ----------- | ------- | -------- |
+    | `appId`     | `string` | Obtained from WeChat client. | N/A         | N/A     | Yes      |
+    | `appSecret` | `string` | Obtained from WeChat client. | N/A         | N/A     | Yes      |
+    | `code`      | `string` | Obtained from WeChat client. | N/A         | N/A     | Yes      |
 
     ---
 
@@ -107,8 +107,8 @@ as well as WeChat-specific functionalities.
         }
         ```
 
-        | Key | Type | Description |
-        | --- | ---- | ----------- |
+        | Key                 | Type     | Description                      |
+        | ------------------- | -------- | -------------------------------- |
         | `uclcssaSessionKey` | `string` | Key representing a user session. |
 
     !!! failure "Missing required key(s)"
@@ -143,9 +143,9 @@ that a valid `uclcssaSessionKey` is required.
     }
     ```
 
-    | Key | Type | Description | Constraints | Default | Required |
-    | --------- | ---- | ----------- | ----------- | ------- | -------- |
-    | `email` | `string` | Email to send confirmation to. | Valid email address. | N/A | Yes |
+    | Key     | Type     | Description                    | Constraints          | Default | Required |
+    | ------- | -------- | ------------------------------ | -------------------- | ------- | -------- |
+    | `email` | `string` | Email to send confirmation to. | Valid email address. | N/A     | Yes      |
 
     ---
 

--- a/docs/authentication-and-authorization.md
+++ b/docs/authentication-and-authorization.md
@@ -111,14 +111,14 @@ as well as WeChat-specific functionalities.
         | --- | ---- | ----------- |
         | `uclcssaSessionKey` | `string` | Key representing a user session. |
 
-    !!! failure "Missing post body"
+    !!! failure "Missing POST body"
         **Status Code**: `400 Bad Request`
 
         **Response Body**:
 
         ```json
         {
-            "message": "Bad request: missing { appId, appSecret, code }."
+            "error": "@bad-request/missing-body"
         }
         ```
     
@@ -129,11 +129,77 @@ as well as WeChat-specific functionalities.
 
         ```json
         {
-            "message": "Bad request: missing one or more of { appId, appSecret, code }."
+            "error": "Bad request: missing one or more of { appId, appSecret, code }."
         }
         ```
 
 ### UCLAPI Registration
+
+**Tier 2** registration. Users who upgrade to the `uclapi-registered` tier must
+already have the `wechat-registered` tier, that is, already registered through
+WeChat.
+
+The user may begin registering for UCLAPI by calling `/register/uclapi`. Note
+that a valid `uclcssaSessionKey` is required.
+
+!!! note "`POST /register/uclapi`"
+    !!! warning "Authorization"
+        `wechat-registered`
+
+    **Request body**:
+
+    ```typescript
+    {
+        email: string
+    }
+    ```
+
+    | Key | Type | Description | Constraints | Default | Required |
+    | --------- | ---- | ----------- | ----------- | ------- | -------- |
+    | `email` | `string` | Email to send confirmation to. | Valid email address. | N/A | Yes |
+
+    ---
+
+    !!! success
+        Successful request. A confirmation email will be sent to the specified
+        address.
+
+        **Status Code**: `200 OK`
+
+    !!! failure "Missing required email"
+        **Status Code**: `400 Bad Request`
+
+        **Response Body**:
+
+        ```json
+        {
+            "error": "@bad-request/missing-email"
+        }
+        ```
+
+    !!! failure "Invalid email address"
+        **Status Code**: `400 Bad Request`
+
+        **Response Body**:
+
+        ```json
+        {
+            "error": "@bad-request/invalid-email"
+        }
+        ```
+
+    !!! failure "Missing `Authorization` header"
+        Missing `Authorization` header.
+
+        **Status Code**: `400 Bad Request`
+
+        **Response Body**:
+
+        ```json
+        {
+            "error": "@bad-request/missing-authorization-header"
+        }
+        ```
 
 ### Logging Out
 
@@ -150,7 +216,7 @@ invalidating his/her session. After logging out, the user's associated WeChat
     !!! success
         **Status Code**: `200 OK`
     
-    !!! failure "Missing header"
+    !!! failure "Missing `Authorization` header"
         Missing `Authorization` header.
 
         **Status Code**: `400 Bad Request`
@@ -159,7 +225,7 @@ invalidating his/her session. After logging out, the user's associated WeChat
 
         ```json
         {
-            "message": "Missing required Authorization header."
+            "error": "@bad-request/missing-authorization-header"
         }
         ```
     
@@ -173,7 +239,7 @@ invalidating his/her session. After logging out, the user's associated WeChat
 
         ```json
         {
-            "message": "Invalid uclcssaSessionKey."
+            "error": "@forbidden/invalid-uclcssa-session-key"
         }
         ```
 

--- a/docs/error-reporting.md
+++ b/docs/error-reporting.md
@@ -28,6 +28,6 @@ happen because `uclcssaSessionKey` is either expired or invalid.
 
     ```json
     {
-        "error": "@forbidden/uclcssa-session-key-expired"
+        "error": "@forbidden/invalid-uclcssa-session-key"
     }
     ```

--- a/docs/error-reporting.md
+++ b/docs/error-reporting.md
@@ -1,0 +1,33 @@
+# Error Reporting
+
+To make using UCLCSSA API as pleasent as possible, all API endpoints strive to
+have a uniform error reporting format.
+
+Firstly, HTTP status codes are used semantically to convey success or failure.
+Any 2XX codes shall indicate successful request. Any 4XX codes shall indicate
+failure. Any 5XX codes shall indicate unexpected errors.
+
+For 4XX errors, such as `400 Bad Request`, `403 Forbidden`, any endpoints
+returning those status codes shall return a JSON response containing a detailed
+`error`.
+
+An `error` is a short string of the format `@http-status/detailed-error-type`.
+For example, missing the `Authorization` header in a request made to a protected
+endpoint will give an `error` of `@bad-request/missing-authorization-header`.
+
+The client may choose to check `error` for detailed error causes, as
+`400 Bad Request` may happen due to different reasons, and `403 Forbidden` may
+happen because `uclcssaSessionKey` is either expired or invalid.
+
+!!! info "Typical Error Response"
+
+    ```http
+    HTTP/1.1 403 Forbidden
+    Content-Type: application/vnd.uclcssa.v1+json
+    ```
+
+    ```json
+    {
+        "error": "@forbidden/uclcssa-session-key-expired"
+    }
+    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,9 +34,9 @@ A typical endpoint is documentated in the following format:
 
     **Query Parameter(s)**:
 
-    | Parameter | Type | Description | Constraints | Default | Required |
-    | --------- | ---- | ----------- | ----------- | ------- | -------- |
-    | `query_parameter` | `int` | Some non-negative int. | `> 0 && <= 100` | `1` | Yes |
+    | Parameter         | Type  | Description            | Constraints     | Default | Required |
+    | ----------------- | ----- | ---------------------- | --------------- | ------- | -------- |
+    | `query_parameter` | `int` | Some non-negative int. | `> 0 && <= 100` | `1`     | Yes      |
 
     **Request Body**:
 
@@ -50,11 +50,11 @@ A typical endpoint is documentated in the following format:
     }
     ```
 
-    | Key | Type | Description | Constraints | Default | Required |
-    | --------- | ---- | ----------- | ----------- | ------- | -------- |
-    | `keyA` | `string` | Hello World. | Not empty. | `''` | No |
-    | `nestedGroup.xxx` | `int` | Hello World. | `>= 0` | `0` | No |
-    | `nestedGroup.yyy` | `int[]` | Numbers. | Length `>= 0` | `[]` | Yes |
+    | Key               | Type     | Description  | Constraints   | Default | Required |
+    | ----------------- | -------- | ------------ | ------------- | ------- | -------- |
+    | `keyA`            | `string` | Hello World. | Not empty.    | `''`    | No       |
+    | `nestedGroup.xxx` | `int`    | Hello World. | `>= 0`        | `0`     | No       |
+    | `nestedGroup.yyy` | `int[]`  | Numbers.     | Length `>= 0` | `[]`    | Yes      |
 
     ---
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -65,10 +65,6 @@ format. Hence, all endpoints will omit the `Content-Type` header.
     ```http
     HTTP/1.1 200 OK
     Content-Type: application/vnd.uclcssa.v1+json
-
-    {
-        "message": "Successfully logged out."
-    }
     ```
 
     ```http
@@ -76,6 +72,6 @@ format. Hence, all endpoints will omit the `Content-Type` header.
     Content-Type: application/vnd.uclcssa.v1+json
 
     {
-        "message": "Missing Authorization header."
+        "error": "@bad-request/missing-authorization-header"
     }
     ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ repo_url: 'https://github.com/UCLCSSA/API-Documentation'
 nav:
   - Home: index.md
   - Versioning: versioning.md
+  - Error Reporting: error-reporting.md
   - Authentication and Authorization: authentication-and-authorization.md
 
 # Theme


### PR DESCRIPTION
Update docs for a uniform error reporting interface.

All 4XX 5XX error responses now has the body

```json
{
    "error": "@http-status/detailed-error-type"
}
```

With `error` being of the format `@http-status/detailed-error-type`.

This allows clients to differentiate causes of errors such as `400 Bad Request`.