### PR TITLE
Add UCLAPI registration related endpoints

### DIFF
--- a/docs/authentication-and-authorization.md
+++ b/docs/authentication-and-authorization.md
@@ -238,7 +238,7 @@ valid for *30 minutes*.
         **Response Header(s)**:
 
         ```http
-        Location: https://uclapi.com/oauth/authorize?client_id={clientId}&state={openId}
+        Location: https://uclapi.com/oauth/authorize?client_id=...&state=...
         ```
 
     !!! failure "Missing `uclapiRegistrationCode`"


### PR DESCRIPTION
Add documentation for UCLAPI registration endpoints:

- `POST /register/uclapi`
- `GET /authorize/uclapi?uclapiRegistrationCode=...`
- `GET /authorize/uclapi/callback?client_id=...&state=...&result=...&code=...`

Note that the two `GET` endpoints are limited by UCLAPI and email, and cannot be `POST` which would more accurately reflect the nature of the endpoints.